### PR TITLE
Adding PrepareSchemaIfNecessary property to create schema automatically

### DIFF
--- a/hangfire-webapi/Startup.cs
+++ b/hangfire-webapi/Startup.cs
@@ -1,16 +1,10 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Hangfire;
+using Hangfire.SqlServer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.HttpsPolicy;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 
 namespace hangfire_webapi
 {
@@ -26,7 +20,10 @@ namespace hangfire_webapi
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddHangfire(x => x.UseSqlServerStorage(@"Data Source=etr\sqlserver;Initial Catalog=hangfire-webapi-db;Integrated Security=True;Pooling=False"));
+            services.AddHangfire(x => x.UseSqlServerStorage(Configuration.GetConnectionString("HangfireDbConnection"), new SqlServerStorageOptions
+            {
+                PrepareSchemaIfNecessary = true,
+            })); 
             services.AddHangfireServer();
             services.AddControllers();
         }

--- a/hangfire-webapi/appsettings.json
+++ b/hangfire-webapi/appsettings.json
@@ -6,5 +6,8 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
+  "ConnectionStrings": {
+    "HangfireDbConnection": "Data Source=etr\\sqlserver;Initial Catalog=hangfire-webapi-db;Integrated Security=True;Pooling=False"
+  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
Because of the below error adding **PrepareSchemaIfNecessary** property to create schema automatically. 

`Invalid object name 'HangFire.AggregatedCounter'`

Also adding code named "HangfireDbConnection" which provides to read connection string from appsettings.json file